### PR TITLE
Terasaki/enhance gess code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ gat_jll = "b88765aa-e0a2-5b02-b897-840ea4e6307e"
 [compat]
 Aqua = "0.8.9"
 IOCapture = "0.2"
-InteractiveUtils = "1.11.0"
+InteractiveUtils = "1"
 JET = "0.9.12"
 Markdown = "1"
 TerminalPager = "0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 TerminalPager = "0c614874-6106-40ed-a7c2-2f1cd0bff883"
 gat_jll = "b88765aa-e0a2-5b02-b897-840ea4e6307e"
@@ -12,6 +13,7 @@ gat_jll = "b88765aa-e0a2-5b02-b897-840ea4e6307e"
 [compat]
 Aqua = "0.8.9"
 IOCapture = "0.2"
+InteractiveUtils = "1.11.0"
 JET = "0.9.12"
 Markdown = "1"
 TerminalPager = "0.5"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ julia> using Pkg; Pkg.add("TerminalGat")
 
 ## How to use
 
-Our Julia package `TerminalGat.jl` exports `gat`, and `gess` functions.
+Our Julia package `TerminalGat.jl` exports 
+
+- `gat`
+- `gess`
+- `@gess`
+- `@code`
+- `@gode`
 
 ### `gat`
 
@@ -53,3 +59,15 @@ julia> gess("Project.toml")
 ```
 
 Internally, our package uses [`ronisbr/TerminalPager.jl`](https://github.com/ronisbr/TerminalPager.jl) to scroll through content that does not fit in the screen.
+
+### `@gess`, `@code`, `@gode`
+
+The `@gess` macro works like `InteractiveUtils.@less`, but highlights Julia code.
+
+<img width="864" alt="image" src="https://github.com/user-attachments/assets/956925ae-ace7-4e53-8b93-3ca3b08d22f1">
+
+The `@code' extracts a method definition from the source code that defines the method.
+
+The `@gode` macro works like `@code`, but highlights Julia code.
+
+<img width="552" alt="image" src="https://github.com/user-attachments/assets/a261fd09-30a0-4f14-84e3-ab9db1eae7fb">

--- a/src/TerminalGat.jl
+++ b/src/TerminalGat.jl
@@ -4,7 +4,7 @@ using InteractiveUtils: gen_call_with_extracted_types
 using Markdown: Markdown
 
 using gat_jll: gat_jll
-export gat, gess, @gess, @gode
+export gat, gess, @gess, @code, @gode
 
 using IOCapture: IOCapture
 using TerminalPager: pager
@@ -140,6 +140,18 @@ function gode(args...)
 end
 
 """
+    gode(Function, types)
+
+Print the definition of a function
+"""
+function code(args...)
+    file, linenum = functionloc(args...)
+    lines = readlines(file)[linenum:end]
+    str = extractcode(lines)
+    print(str)
+end
+
+"""
     @gode(ex0)
 
 Applied to a function or macro call, it evaluates the arguments to the specified call, and returns code giving the location for the method that would be called for those arguments. 
@@ -148,6 +160,17 @@ It calls out to the `gode` function.
 macro gode(ex0)
     ex = gen_call_with_extracted_types(__module__, :gode, ex0)
 end
+
+"""
+    @gode(ex0)
+
+Applied to a function or macro call, it evaluates the arguments to the specified call, and returns code giving the location for the method that would be called for those arguments. 
+It calls out to the `gode` function.
+"""
+macro code(ex0)
+    ex = gen_call_with_extracted_types(__module__, :code, ex0)
+end
+
 
 """
     gat(md::Markdown.MD)

--- a/src/TerminalGat.jl
+++ b/src/TerminalGat.jl
@@ -136,7 +136,7 @@ function gode(args...)
     open(pipeline(`$(gat_jll.gat()) --theme monokai --force-color --lang julia`), "w", io) do f
         println(f, str)
     end
-    (String(take!(io))) |> pager
+    print(String(take!(io)))
 end
 
 """

--- a/src/TerminalGat.jl
+++ b/src/TerminalGat.jl
@@ -1,5 +1,6 @@
 module TerminalGat
 
+using InteractiveUtils: gen_call_with_extracted_types
 using Markdown: Markdown
 
 using gat_jll: gat_jll
@@ -77,6 +78,27 @@ function gess(filename::AbstractString)
         gat(filename)
     end
     c.output |> pager
+end
+
+function gess(filename::AbstractString, line::Integer)
+    lines = open(filename, "r") do f
+        for _ in 1:line-1
+            readline(f)
+        end
+        lines = readlines(f)
+    end
+    str = join(lines, "\n")
+    io = IOBuffer()
+    open(pipeline(`$(gat_jll.gat()) --theme monokai --force-color --lang julia`), "w", io) do f
+        println(f, str)
+    end
+    (String(take!(io))) |> pager
+end
+
+gess(f, @nospecialize t)  = gess(functionloc(f,t)...)
+
+macro gess(ex0)
+    ex = gen_call_with_extracted_types(__module__, :gess, ex0)
 end
 
 """

--- a/src/TerminalGat.jl
+++ b/src/TerminalGat.jl
@@ -4,7 +4,7 @@ using InteractiveUtils: gen_call_with_extracted_types
 using Markdown: Markdown
 
 using gat_jll: gat_jll
-export gat, gess
+export gat, gess, @gess, @gode
 
 using IOCapture: IOCapture
 using TerminalPager: pager
@@ -99,6 +99,54 @@ gess(f, @nospecialize t)  = gess(functionloc(f,t)...)
 
 macro gess(ex0)
     ex = gen_call_with_extracted_types(__module__, :gess, ex0)
+end
+
+"""
+    extractcode(lines::Vector{String})
+
+Extract code that reporensents the definition of a function from `lines`, scanning
+`lines` line by line using `Meta.parse`.
+"""
+function extractcode(lines::Vector{String})
+    r = -1
+    for n in eachindex(lines)
+        try
+            expr = Meta.parse(join(lines[1:n], "\n"), raise = true)
+            if expr.head !== :incomplete
+                r = n
+                break
+            end
+        catch e
+            e isa Meta.ParseError && continue
+        end
+    end
+    join(lines[begin:r], "\n")
+end
+
+"""
+    gode(Function, types)
+
+Print the definition of a function
+"""
+function gode(args...)
+    file, linenum = functionloc(args...)
+    lines = readlines(file)[linenum:end]
+    str = extractcode(lines)
+    io = IOBuffer()
+    open(pipeline(`$(gat_jll.gat()) --theme monokai --force-color --lang julia`), "w", io) do f
+        println(f, str)
+    end
+    (String(take!(io))) |> pager
+end
+
+"""
+    @gode(ex0)
+
+Applied to a function or macro call, it evaluates the arguments to the specified call, and returns code giving the location for the method that would be called for those arguments. 
+It calls out to the `gode` function.
+"""
+macro gode(ex0)
+    ex = gen_call_with_extracted_types(__module__, :gode, ex0)
 end
 
 """


### PR DESCRIPTION
This PR `@gess, @code, @gode` macros

The `@gess` macro works like `InteractiveUtils.@less`, but highlights Julia code.

<img width="864" alt="image" src="https://github.com/user-attachments/assets/956925ae-ace7-4e53-8b93-3ca3b08d22f1">

The `@code' extracts a method definition from the source code that defines the method.

The `@gode` macro works like `@code`, but highlights Julia code.

<img width="552" alt="image" src="https://github.com/user-attachments/assets/a261fd09-30a0-4f14-84e3-ab9db1eae7fb">
