### PR TITLE
Simplify `@search` and `@gearch`

### DIFF
--- a/src/TerminalGat.jl
+++ b/src/TerminalGat.jl
@@ -276,7 +276,7 @@ end
 """
     @search f [mod]
 
-It works like `method(f, [mod::Module])` with the Fizzy Finder feature. 
+It works like `methods(f, [mod::Module])` with the Fizzy Finder feature. 
 Then print a code that gives the method definition of f specified by the user.
 """
 macro search(fn::Symbol, mod::Symbol)
@@ -286,7 +286,7 @@ end
 """
     @gearch f [mod]
 
-It works like `method(f, [mod::Module])` with the Fizzy Finder feature. 
+It works like `methods(f, [mod::Module])` with the Fizzy Finder feature. 
 Then print a highlighted code that gives the method definition of f specified by the user.
 """
 macro gearch(fn::Symbol, mod::Symbol)

--- a/src/TerminalGat.jl
+++ b/src/TerminalGat.jl
@@ -265,22 +265,14 @@ function gearch(@nospecialize(f),
     return gearch(f, Tuple{Vararg{Any}}, mod)
 end
 
-macro search(fn::Symbol)
-    :(search($(esc(fn))))
-end
-
-macro gearch(fn::Symbol)
-    :(gearch($(esc(fn))))
-end
-
 """
     @search f [mod]
 
 It works like `methods(f, [mod::Module])` with the Fizzy Finder feature. 
 Then print a code that gives the method definition of f specified by the user.
 """
-macro search(fn::Symbol, mod::Symbol)
-    :(search($(esc(fn)), $(esc(mod))))
+macro search(fn)
+    :(search($(esc(fn))))
 end
 
 """
@@ -289,8 +281,8 @@ end
 It works like `methods(f, [mod::Module])` with the Fizzy Finder feature. 
 Then print a highlighted code that gives the method definition of f specified by the user.
 """
-macro gearch(fn::Symbol, mod::Symbol)
-    :(gearch($(esc(fn)), $(esc(mod))))
+macro gearch(fn)
+    :(gearch($(esc(fn))))
 end
 
 end # module


### PR DESCRIPTION
The current implementation on the main branch does not work with the case `@search Base.nextpatch`. This PR fixes the issue.